### PR TITLE
Run in Docker to run fontforge etc in container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+lib/fontcustom/scripts/sfnt2woff
+lib/fontcustom/scripts/sfnt2woff.exe
+spec/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:3.3-bullseye
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends fontforge sfnt2woff-zopfli woff2 && \
+    apt-get clean && \
+    ln -s /usr/bin/sfnt2woff-zopfli /usr/local/bin/sfnt2woff # fontcustom calls `sfnt2woff-zopfil` without suffix
+
+COPY . /app/fontcustom
+RUN bundle config set without development && bundle install --gemfile /app/fontcustom/Gemfile
+
+WORKDIR /data
+
+ENTRYPOINT ["bundle", "exec", "--gemfile", "/app/fontcustom/Gemfile", "fontcustom"]


### PR DESCRIPTION
Due to the difficulty of maintaining an environment where tools like FontForge works in the local environments of developers and designers, I have made it run within a container.