### PR TITLE
New options to support migration from existing font build environments

### DIFF
--- a/lib/fontcustom/generator/font.rb
+++ b/lib/fontcustom/generator/font.rb
@@ -52,6 +52,7 @@ module Fontcustom
         files.each do |file|
           name = File.basename file, ".svg"
           name = name.strip.gsub(/\W/, "-")
+          name.gsub!(/\A\d+_/, '') if @options[:input][:drop_number_prefix]
           glyphs[name.to_sym] = { :source => file }
           if File.read(file).include? "rgba"
             say_message :warn, "`#{file}` contains transparency and will be skipped."
@@ -60,7 +61,7 @@ module Fontcustom
 
         # Dir.glob returns a different order depending on ruby
         # version/platform, so we have to sort it first
-        glyphs = Hash[glyphs.sort_by { |key, val| key.to_s }]
+        glyphs = Hash[glyphs.sort_by { |key, val| val[:source] }]
         glyphs.each do |name, data|
           if manifest_glyphs.has_key? name
            data[:codepoint] = manifest_glyphs[name][:codepoint]

--- a/lib/fontcustom/generator/font.rb
+++ b/lib/fontcustom/generator/font.rb
@@ -44,7 +44,7 @@ module Fontcustom
         else
           # Offset to work around Chrome Windows bug
           # https://github.com/FontCustom/fontcustom/issues/1
-          0xf100
+          @options[:base_codepoint] || 0xf100
         end
 
         files = Dir.glob File.join(@options[:input][:vectors], "*.svg")


### PR DESCRIPTION
Added options to control the behavior of font generation to make migration easier in existing projects.

- Added `drop_number_prefix` to drop serial numbers from SVG filename for cases where the SVG file name and font glyph name are different.
- Made it possible to specify the starting code point `code_point` option.